### PR TITLE
Quick and dirty way to retrieve the path of the current pid file

### DIFF
--- a/lib/pid.js
+++ b/lib/pid.js
@@ -1,15 +1,22 @@
 (function () {
   "use strict";
 
-  var fs = require('fs'); 
+  var fs = require('fs');
+  var _path;
 
   module.exports = function (path) {
+    if(typeof path === 'undefined') {
+      return _path;
+    }
+
     if (!/\//.test(path)) {
       if (!/\.pid/.test(path)) {
         path += '.pid';
       }
       path = '/tmp/' + path;
     }
+
+    _path = path;
 
     fs.writeFile(path, process.pid.toString() + '\n');
     process.on('exit', function () {


### PR DESCRIPTION
We had a use case for retrieving the pidfile after the case, and this was a quick and dirty patch which is backwards compatible.  What do you think?
